### PR TITLE
correct jquery-once library dependency

### DIFF
--- a/openseadragon.libraries.yml
+++ b/openseadragon.libraries.yml
@@ -7,5 +7,5 @@ init:
       css/openseadragon.css: {}
   dependencies:
       - core/jquery
-      - core/jquery-once
+      - core/jquery.once
       - core/drupalSettings


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/864

# What does this Pull Request do?

Corrects the jquery-once library dependency.

# What's new?

Changed 'core/jquery-once' to 'core/jquery.once' as defined by [core.libraries.yml](http://cgit.drupalcode.org/drupal/tree/core/core.libraries.yml).

# How should this be tested?

* Apply the PR
* (If you don't have one already) create a repository item with the tag "Open Seadragon" and a linked preservation master media .
* log out of Drupal
* View the item as Anonymous User.
* The page should load the Open Seadragon viewer properly. 

# Additional Notes:

As @DiegoPino mentioned in the ticket, Drupal needs us to tell it which libraries to load. All the dependencies were being met (and thus the view worked) when you are logged in but were not being met when logged out due to a typo in the dependency listing. 

# Interested parties
@Islandora-CLAW/committers
