### PR TITLE
Changes for using HttpResolver

### DIFF
--- a/openseadragon.module
+++ b/openseadragon.module
@@ -83,10 +83,12 @@ function template_preprocess_openseadragon_formatter(&$variables) {
   $iiif_address = $config->getIiifAddress();
 
   if (!is_null($iiif_address) && !empty($iiif_address) && array_key_exists('full_path', $resource)) {
-    // Strip the root off to get the relative to root file path.
-    $full_path = str_replace(DRUPAL_ROOT . '/', '', $resource['full_path']);
+    // Get the path to the file by stripping off the site's base url.
+    $base = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
+    $path = str_replace($base, "", $resource['full_path']);
 
-    $tile_source = rtrim($iiif_address, '/') . '/' . urlencode($full_path);
+    // Construct the tile source url.
+    $tile_source = rtrim($iiif_address, '/') . '/' . urlencode($path);
 
     $variables['#attached']['drupalSettings']['openseadragon'] = [
       'basePath' => Url::fromUri($iiif_address),

--- a/src/File/FileInformation.php
+++ b/src/File/FileInformation.php
@@ -59,12 +59,7 @@ class FileInformation implements FileInformationInterface {
       }
     }
     $output['mime_type'] = $mime_type;
-
-    // Get the path to the file by stripping off the site's base url.
-    // Heads up, this is already url encoded, so no need to do it again.
-    $base = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
-    $file_url = $file->url();
-    $output['full_path'] = str_replace($base, "", $file_url);
+    $output['full_path'] = $file->url();
     return $output;
   }
 


### PR DESCRIPTION
**GitHub Issue**: Part of https://github.com/Islandora-CLAW/CLAW/issues/769

* https://github.com/Islandora-CLAW/islandora/pull/92

# What does this Pull Request do?

Updates the file information service to return the full http path (e.g. everything after the base url) instead of a file path.  With the Flysystem and Cantaloupe config changes in place, this lets you proxy all your images no matter where they live (public, private, fedora, etc...) through Cantaloupe and display them with openseadragon.

# How should this be tested?

Test as part of https://github.com/Islandora-CLAW/islandora/pull/92

# Interested parties
@Islandora-CLAW/committers
