### PR TITLE
Remove width to make it responsive

### DIFF
--- a/css/openseadragon.css
+++ b/css/openseadragon.css
@@ -1,5 +1,4 @@
 .openseadragon-viewer {
-  width: 600px;
   height: 640px;
   background-color: #000;
 }


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/1105

# What does this Pull Request do?

Removes the openseadragon-viewer width setting (600px) to make it more responsive.

# What's new?

* Removed the openseadragon-viewer width setting (was 600px, now defaults to 100%).
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

* Make an item
* Use the Open Seadragon display helper
* squeeze your window narrow and see the window remain 600px wide
* Apply the PR
* Flush caches
* View the item again and the viewer should adjust as you change your browser window width

# Interested parties
@Natkeeran, @whikloj, @dannylamb 
