### PR TITLE
Fix PHP notices - Issue 1124

### DIFF
--- a/config/install/openseadragon.settings.yml
+++ b/config/install/openseadragon.settings.yml
@@ -9,7 +9,11 @@ default_options:
   immediateRender : FALSE
   defaultZoomLevel : 0
   opacity : 1
+  compositeOperation: ''
+  placeholderFillStyle: ''
   degrees : 0
+  minZoomLevel: ''
+  maxZoomLevel: ''
   homeFillsViewer : FALSE
   panHorizontal : TRUE
   panVertical : TRUE
@@ -74,6 +78,10 @@ default_options:
   navigatorPosition : 'TOP_RIGHT'
   navigatorSizeRatio : 0.2
   navigatorMaintainSizeRatio : FALSE
+  navigatorTop: ''
+  navigatorLeft: ''
+  navigatorHeight: ''
+  navigatorWidth: ''
   navigatorAutoResize : TRUE
   navigatorAutoFade : TRUE
   navigatorRotate : TRUE
@@ -99,6 +107,8 @@ default_options:
   preserveOverlays : FALSE
   showReferenceStrip : FALSE
   referenceStripScroll : 'horizontal'
+  referenceStripHeight: ''
+  referenceStripWidth: ''
   referenceStripPosition : 'BOTTOM_LEFT'
   referenceStripSizeRatio : 0.2
   collectionMode : FALSE

--- a/config/install/openseadragon.settings.yml
+++ b/config/install/openseadragon.settings.yml
@@ -1,4 +1,5 @@
 default_options:
+  fit_to_aspect_ratio : FALSE
   tabIndex : 0
   debugMode : FALSE
   debugGridColor : '#437AB2'

--- a/src/Form/OpenSeadragonSettingsForm.php
+++ b/src/Form/OpenSeadragonSettingsForm.php
@@ -105,7 +105,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
       'fit_to_aspect_ratio' => [
         '#type' => 'checkbox',
         '#title' => t('Constrain image to viewport'),
-        '#default_value' => $settings['fit_to_aspect_ratio'],
+        '#default_value' => isset($settings['fit_to_aspect_ratio']) ? $settings['fit_to_aspect_ratio'] : '',
         '#description' => t('On the initial page load, the entire image will be visible in the viewport.'),
       ],
       // We don't provide "id" as configurable to users.
@@ -177,7 +177,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#type' => 'select',
         '#title' => t('Composite Operation'),
         '#description' => t('How the image is composited onto other images.'),
-        '#default_value' => $settings['compositeOperation'],
+        '#default_value' => isset($settings['compositeOperation']) ? $settings['compositeOperation'] : '',
         '#options' => array_combine(
           [
             NULL,
@@ -212,7 +212,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
       'placeholderFillStyle' => [
         '#type' => 'textfield',
         '#title' => t('Placeholder Fill Style'),
-        '#default_value' => $settings['placeholderFillStyle'],
+        '#default_value' => isset($settings['placeholderFillStyle']) ? $settings['placeholderFillStyle'] : '',
         '#description' => t('Draws a colored rectangle behind the tile if it is not loaded yet. You can pass a CSS color value like "#FF8800".'),
       ],
       'degrees' => [
@@ -228,7 +228,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#title' => t('Minimum Zoom Level'),
         '#size' => 10,
         '#element_validate' => [[$this, 'elementValidateNumber']],
-        '#default_value' => $settings['minZoomLevel'],
+        '#default_value' => isset($settings['minZoomLevel']) ? $settings['minZoomLevel'] : '',
         '#description' => t('Minimum Zoom Level (integer).'),
       ],
       'maxZoomLevel' => [
@@ -236,7 +236,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#title' => t('Maximum Zoom Level'),
         '#size' => 10,
         '#element_validate' => [[$this, 'elementValidateNumber']],
-        '#default_value' => $settings['maxZoomLevel'],
+        '#default_value' => isset($settings['maxZoomLevel']) ? $settings['maxZoomLevel'] : '',
         '#description' => t('Maximum Zoom Level (integer).'),
       ],
       'homeFillsViewer' => [
@@ -695,7 +695,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Top Position'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => $settings['navigatorTop'],
+            '#default_value' => isset($settings['navigatorTop']) ? $settings['navigatorTop'] : '',
             '#description' => t('Specifies the location of the navigator minimap (see Navigator Position).'),
           ],
           'navigatorLeft' => [
@@ -703,7 +703,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Left Position'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => $settings['navigatorLeft'],
+            '#default_value' => isset($settings['navigatorLeft']) ? $settings['navigatorLeft'] : '',
             '#description' => t('Specifies the location of the navigator minimap (see Navigator Position).'),
           ],
           'navigatorHeight' => [
@@ -711,7 +711,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Height'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => $settings['navigatorHeight'],
+            '#default_value' => isset($settings['navigatorHeight']) ? $settings['navigatorHeight'] : '',
             '#description' => t('Specifies the size of the navigator minimap (see Navigator Position). If specified, Navigator Size Ratio and Navigator Maintain Size Ratio are ignored.'),
           ],
           'navigatorWidth' => [
@@ -719,7 +719,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Width'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => $settings['navigatorWidth'],
+            '#default_value' => isset($settings['navigatorWidth']) ? $settings['navigatorWidth'] : '',
             '#description' => t('Specifies the size of the navigator minimap (see Navigator Position). If specified, Navigator Size Ratio and Navigator Maintain Size Ratio are ignored.'),
           ],
           'navigatorAutoResize' => [
@@ -942,7 +942,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
               '#title' => t('Reference Strip Height'),
               '#size' => 10,
               '#element_validate' => [[$this, 'elementValidateNumber']],
-              '#default_value' => $settings['referenceStripHeight'],
+              '#default_value' => isset($settings['referenceStripHeight']) ? $settings['referenceStripHeight'] : '',
               '#description' => t('Height of the reference strip in pixels.'),
             ],
             'referenceStripWidth' => [
@@ -950,7 +950,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
               '#title' => t('Reference Strip Width'),
               '#size' => 10,
               '#element_validate' => [[$this, 'elementValidateNumber']],
-              '#default_value' => $settings['referenceStripWidth'],
+              '#default_value' => isset($settings['referenceStripWidth']) ? $settings['referenceStripWidth'] : '',
               '#description' => t('Width of the reference strip in pixels.'),
             ],
             'referenceStripPosition' => [

--- a/src/Form/OpenSeadragonSettingsForm.php
+++ b/src/Form/OpenSeadragonSettingsForm.php
@@ -764,17 +764,9 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#default_value' => $settings['controlsFadeLength'],
         '#description' => t('The number of milliseconds to animate the controls fading out.'),
       ],
-      'controlsFadeDelay' => [
-        '#type' => 'textfield',
-        '#title' => t('Controls Fade Delay'),
-        '#size' => 10,
-        '#element_validate' => [[$this, 'elementValidateNumber']],
-        '#default_value' => $settings['controlsFadeDelay'],
-        '#description' => t('The number of milliseconds to wait once the user has stopped interacting with the interface before begining to fade the controls. Assumes showNavigationControl and autoHideControls are both true.'),
-      ],
       'maxImageCacheCount' => [
         '#type' => 'textfield',
-        '#title' => t('Controls Fade Delay'),
+        '#title' => t('Max Image Cache Count'),
         '#size' => 10,
         '#element_validate' => [[$this, 'elementValidateNumber']],
         '#default_value' => $settings['maxImageCacheCount'],
@@ -782,7 +774,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
       ],
       'timeout' => [
         '#type' => 'textfield',
-        '#title' => t('timeout'),
+        '#title' => t('Timeout'),
         '#size' => 10,
         '#element_validate' => [[$this, 'elementValidateNumber']],
         '#default_value' => $settings['timeout'],

--- a/src/Form/OpenSeadragonSettingsForm.php
+++ b/src/Form/OpenSeadragonSettingsForm.php
@@ -105,7 +105,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
       'fit_to_aspect_ratio' => [
         '#type' => 'checkbox',
         '#title' => t('Constrain image to viewport'),
-        '#default_value' => isset($settings['fit_to_aspect_ratio']) ? $settings['fit_to_aspect_ratio'] : '',
+        '#default_value' => $settings['fit_to_aspect_ratio'],
         '#description' => t('On the initial page load, the entire image will be visible in the viewport.'),
       ],
       // We don't provide "id" as configurable to users.
@@ -177,7 +177,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#type' => 'select',
         '#title' => t('Composite Operation'),
         '#description' => t('How the image is composited onto other images.'),
-        '#default_value' => isset($settings['compositeOperation']) ? $settings['compositeOperation'] : '',
+        '#default_value' => $settings['compositeOperation'],
         '#options' => array_combine(
           [
             NULL,
@@ -212,7 +212,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
       'placeholderFillStyle' => [
         '#type' => 'textfield',
         '#title' => t('Placeholder Fill Style'),
-        '#default_value' => isset($settings['placeholderFillStyle']) ? $settings['placeholderFillStyle'] : '',
+        '#default_value' => $settings['placeholderFillStyle'],
         '#description' => t('Draws a colored rectangle behind the tile if it is not loaded yet. You can pass a CSS color value like "#FF8800".'),
       ],
       'degrees' => [
@@ -228,7 +228,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#title' => t('Minimum Zoom Level'),
         '#size' => 10,
         '#element_validate' => [[$this, 'elementValidateNumber']],
-        '#default_value' => isset($settings['minZoomLevel']) ? $settings['minZoomLevel'] : '',
+        '#default_value' => $settings['minZoomLevel'],
         '#description' => t('Minimum Zoom Level (integer).'),
       ],
       'maxZoomLevel' => [
@@ -236,7 +236,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
         '#title' => t('Maximum Zoom Level'),
         '#size' => 10,
         '#element_validate' => [[$this, 'elementValidateNumber']],
-        '#default_value' => isset($settings['maxZoomLevel']) ? $settings['maxZoomLevel'] : '',
+        '#default_value' => $settings['maxZoomLevel'],
         '#description' => t('Maximum Zoom Level (integer).'),
       ],
       'homeFillsViewer' => [
@@ -695,7 +695,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Top Position'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => isset($settings['navigatorTop']) ? $settings['navigatorTop'] : '',
+            '#default_value' => $settings['navigatorTop'],
             '#description' => t('Specifies the location of the navigator minimap (see Navigator Position).'),
           ],
           'navigatorLeft' => [
@@ -703,7 +703,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Left Position'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => isset($settings['navigatorLeft']) ? $settings['navigatorLeft'] : '',
+            '#default_value' => $settings['navigatorLeft'],
             '#description' => t('Specifies the location of the navigator minimap (see Navigator Position).'),
           ],
           'navigatorHeight' => [
@@ -711,7 +711,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Height'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => isset($settings['navigatorHeight']) ? $settings['navigatorHeight'] : '',
+            '#default_value' => $settings['navigatorHeight'] ,
             '#description' => t('Specifies the size of the navigator minimap (see Navigator Position). If specified, Navigator Size Ratio and Navigator Maintain Size Ratio are ignored.'),
           ],
           'navigatorWidth' => [
@@ -719,7 +719,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
             '#title' => t('Navigator Width'),
             '#size' => 10,
             '#element_validate' => [[$this, 'elementValidateNumber']],
-            '#default_value' => isset($settings['navigatorWidth']) ? $settings['navigatorWidth'] : '',
+            '#default_value' => $settings['navigatorWidth'],
             '#description' => t('Specifies the size of the navigator minimap (see Navigator Position). If specified, Navigator Size Ratio and Navigator Maintain Size Ratio are ignored.'),
           ],
           'navigatorAutoResize' => [
@@ -934,7 +934,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
               '#title' => t('Reference Strip Height'),
               '#size' => 10,
               '#element_validate' => [[$this, 'elementValidateNumber']],
-              '#default_value' => isset($settings['referenceStripHeight']) ? $settings['referenceStripHeight'] : '',
+              '#default_value' => $settings['referenceStripHeight'],
               '#description' => t('Height of the reference strip in pixels.'),
             ],
             'referenceStripWidth' => [
@@ -942,7 +942,7 @@ class OpenSeadragonSettingsForm extends ConfigFormBase {
               '#title' => t('Reference Strip Width'),
               '#size' => 10,
               '#element_validate' => [[$this, 'elementValidateNumber']],
-              '#default_value' => isset($settings['referenceStripWidth']) ? $settings['referenceStripWidth'] : '',
+              '#default_value' => $settings['referenceStripWidth'],
               '#description' => t('Width of the reference strip in pixels.'),
             ],
             'referenceStripPosition' => [


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/1124 and Islandora-CLAW/CLAW/issues/1125

# What does this Pull Request do?

Resolves PHP notices about missing settings for the viewer and settings form. Also fixes some minor form errors.

# What's new?

* Changes various form default setting code to see if the setting is set and using blank values if not.
* Added fit_to_aspect_ratio to openseadragon.settings (set to false, makes explicit that which was implicit)
* Removed a duplicate settings form item (controlsFadeDelay) and fixes the title for another (maxImageCacheCount)
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

* View an item with the Open Seadragon viewer
* View the Open Seadragon settings form (http://localhost:8000/admin/config/media/openseadragon)
* Check the log (http://localhost:8000/admin/reports/dblog) and you should see a bunch of notices corresponding to the original issue.
* Apply the PR
* Since we don't have features to help us: import the new openseadragon.settings using the Config Sync tool (http://localhost:8000/admin/config/development/configuration/single/import) using the "Simple Configuration" type.
* View the item again.
* View the Open Seadragon settings form again.
* There should be no new notices in your logs.

# Interested parties
@kayakr, @Islandora-CLAW/committers
