### PR TITLE
Pass the full URI to IIIF server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 7.1
   - 7.2
 
+services:
+  - mysql
+
 matrix:
     fast_finish: true
 

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -85,7 +85,7 @@ function template_preprocess_openseadragon_formatter(&$variables) {
   if (!is_null($iiif_address) && !empty($iiif_address) && array_key_exists('full_path', $resource)) {
 
     // Construct the tile source url.
-    $tile_source = rtrim($iiif_address, '/') . '/' . urlencode($path);
+    $tile_source = rtrim($iiif_address, '/') . '/' . urlencode($resource['full_path']);
 
     $variables['#attached']['drupalSettings']['openseadragon'] = [
       'basePath' => Url::fromUri($iiif_address),

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -83,9 +83,6 @@ function template_preprocess_openseadragon_formatter(&$variables) {
   $iiif_address = $config->getIiifAddress();
 
   if (!is_null($iiif_address) && !empty($iiif_address) && array_key_exists('full_path', $resource)) {
-    // Get the path to the file by stripping off the site's base url.
-    $base = Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString();
-    $path = str_replace($base, "", $resource['full_path']);
 
     // Construct the tile source url.
     $tile_source = rtrim($iiif_address, '/') . '/' . urlencode($path);

--- a/src/File/FileInformation.php
+++ b/src/File/FileInformation.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\openseadragon\File;
 
-use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1226
This possibly also resolves https://github.com/Islandora-CLAW/CLAW/issues/1121

#### Other Relevant Links
* https://github.com/Islandora-Devops/claw-playbook/pull/139

# What does this Pull Request do?

Stops stripping the base URI off the file to be passed to Cantaloupe. 

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. Enable a second language in your Islandora 8 site.
1. Make a large image with a Tiff.
1. Translate the node.
1. View the original English, see the Openseadragon viewer work.
1. View the translated version, see the Openseadragon view display an error.
1. Pull this PR in on top of your openseadragon module.
1. Go edit (assuming claw-playbook) `sudo vim /opt/cantaloupe/cantaloupe.properties`
1. Find the line `HttpResolver.BasicLookupStrategy.url_prefix = http://localhost:8000/`
1. Change it to `HttpResolver.BasicLookupStrategy.url_prefix =`
1. Save and close `cantaloupe.properties`
1. Clear Drupal cache.
1. View the translated node again

See the image!

# Interested parties
@Islandora-CLAW/committers @Natkeeran @rangel35 
