### PR TITLE
IIIF manifest block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "irc": "irc://irc.freenode.net/islandora"
   },
   "require": {
-    "drupal/libraries": "dev-3.x"
+    "drupal/libraries": "dev-3.x",
+    "drupal/token": "^1.3"
   },
   "authors": [
     {

--- a/openseadragon.info.yml
+++ b/openseadragon.info.yml
@@ -5,6 +5,7 @@ package: Media
 core: 8.x
 dependencies:
   - libraries
+  - token
 library_dependencies:
   - openseadragon
 configure: openseadragon.admin_settings

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -1,7 +1,5 @@
 <?php
 
-namespace Drupal\openseadragon;
-
 /**
  * @file
  * Main functions and template preprocessor.
@@ -43,7 +41,6 @@ function openseadragon_libraries_info() {
  * Implements hook_theme().
  */
 function openseadragon_theme() {
-	dsm("IN HOOK_THEME");
   return [
     'openseadragon_formatter' => [
       'variables' => [
@@ -112,7 +109,6 @@ function template_preprocess_openseadragon_formatter(&$variables) {
 }
 
 function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
-	dsm("IN PREPROCESS");
   // Load the global settings.
   $config = \Drupal::service('openseadragon.config');
 

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -108,6 +108,9 @@ function template_preprocess_openseadragon_formatter(&$variables) {
   }
 }
 
+/**
+ * Implements template_preprocess_HOOK().
+ */
 function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
   // Load the global settings.
   $config = \Drupal::service('openseadragon.config');

--- a/openseadragon.module
+++ b/openseadragon.module
@@ -1,5 +1,7 @@
 <?php
 
+namespace Drupal\openseadragon;
+
 /**
  * @file
  * Main functions and template preprocessor.
@@ -41,12 +43,18 @@ function openseadragon_libraries_info() {
  * Implements hook_theme().
  */
 function openseadragon_theme() {
+	dsm("IN HOOK_THEME");
   return [
     'openseadragon_formatter' => [
       'variables' => [
         'item' => NULL,
         'entity' => NULL,
         'settings' => NULL,
+      ],
+    ],
+    'openseadragon_iiif_manifest_block' => [
+      'variables' => [
+        'iiif_manifest_url' => NULL,
       ],
     ],
   ];
@@ -101,6 +109,48 @@ function template_preprocess_openseadragon_formatter(&$variables) {
     $variables['attributes']['class'] = $classes_array;
     $variables['attributes']['id'] = $openseadragon_viewer_id;
   }
+}
+
+function template_preprocess_openseadragon_iiif_manifest_block(&$variables) {
+	dsm("IN PREPROCESS");
+  // Load the global settings.
+  $config = \Drupal::service('openseadragon.config');
+
+  // TODO: Once Libraries API is finished find a function for this.
+  $base_library_path = 'sites/all/assets/vendor';
+
+  // Build the gallery id.
+  $openseadragon_viewer_id = 'openseadragon-viewer-iiif-manifest-block';
+
+  $classes_array = ['openseadragon-viewer'];
+  $viewer_settings = $config->getSettings(TRUE);
+  $iiif_address = $config->getIiifAddress();
+
+  // Get the tile sources from the manifest.
+  $parser = \Drupal::service('openseadragon.manifest_parser');
+  $tile_sources = $parser->getTileSources($variables['iiif_manifest_url']);
+
+  if (empty($tile_sources)) {
+    return;
+  }
+
+  // Attach the viewer, using the image urls obtained from the manifest.
+  if (!is_null($iiif_address) && !empty($iiif_address) && !empty($tile_sources)) {
+    $variables['#attached']['drupalSettings']['openseadragon'] = [
+      'basePath' => Url::fromUri($iiif_address),
+      'fitToAspectRatio' => $viewer_settings['fit_to_aspect_ratio'],
+      'options' => [
+        'id' => $openseadragon_viewer_id,
+        'prefixUrl' => file_create_url("{$base_library_path}/openseadragon/images/"),
+        'tileSources' => $tile_sources,
+      ] + $viewer_settings,
+    ];
+
+    $variables['attributes'] = new Attribute();
+    $variables['attributes']['class'] = $classes_array;
+    $variables['attributes']['id'] = $openseadragon_viewer_id;
+  }
+
 }
 
 /**

--- a/openseadragon.services.yml
+++ b/openseadragon.services.yml
@@ -5,3 +5,6 @@ services:
   openseadragon.fileinfo:
     class: Drupal\openseadragon\File\FileInformation
     arguments: ['@file.mime_type.guesser', '@stream_wrapper_manager']
+  openseadragon.manifest_parser:
+    class: Drupal\openseadragon\IIIFManifestParser
+    arguments: ['@token', '@current_route_match']

--- a/openseadragon.services.yml
+++ b/openseadragon.services.yml
@@ -7,4 +7,7 @@ services:
     arguments: ['@file.mime_type.guesser', '@stream_wrapper_manager']
   openseadragon.manifest_parser:
     class: Drupal\openseadragon\IIIFManifestParser
-    arguments: ['@token', '@current_route_match']
+    arguments: ['@token', '@current_route_match', '@http_client', '@logger.channel.openseadragon']
+  logger.channel.openseadragon:
+      parent: logger.channel_base
+      arguments: ['openseadragon']

--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -1,0 +1,77 @@
+<?php
+
+use Drupal\Core\Utility\Token;
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Utility class to extract tile sources from a IIIF manifest.
+ *
+ * @package Drupal\openseadragon
+ */
+class IIIFManifestParser {
+
+  /**
+   * Token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */	
+  protected $token;
+
+  /**
+   * Current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */	
+  protected $routeMatch;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    Token $token,
+    RouteMatchInterface $route_match  
+  ) {
+    $this->token = $token;
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * Extracts the list of tiles sources from a IIIF manifest.
+   *
+   * @param string $manifest_url
+   *   The location of the IIIF manifest, which can include tokens.
+   *
+   * @return array
+   *   The URLs of all the tile sources in a manifest.
+   */
+  public function getTileSources($manifest_url) {
+    // Try to construct the URL out of a tokenized string if the node is available.
+    $current_node = $this->routeMatch->getParameter('node');
+    if ($current_node) {
+      $manifest_url = $this->token->replace($manifest_url, ['node' => $current_node]);
+    }
+
+    // Request the manifest.
+    $manifest = file_get_contents($manifest_url);
+    dsm($manifest);
+    if (empty($manifest)) {
+      return FALSE;
+    }
+
+    // Hack the tile sources out of the manifest.
+    $manifest = json_decode($manifest, TRUE);
+    $tile_sources = [];
+    foreach ($manifest['sequences'] as $sequence) {
+      foreach ($sequence['canvases'] as $canvas) {
+        foreach ($canvas['images'] as $key => $image) {
+          if (is_numeric($key)) {
+            $tile_sources[] = $image['resource']['service']['@id'];
+          }
+        }
+      }
+    }
+
+    return $tile_sources;
+  }
+
+}

--- a/src/IIIFManifestParser.php
+++ b/src/IIIFManifestParser.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Drupal\openseadragon;
+
 use Drupal\Core\Utility\Token;
 use Drupal\Core\Routing\RouteMatchInterface;
 

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -26,16 +26,23 @@ class OpenseadragonBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function blockForm($form, FormStateInterface $form_state) {
-    $form['iiif_manifest_url'] = [
-      '#type' => 'textfield',
+    $form['iiif_manifest_url_fieldset'] = [
+      '#type' => 'fieldset',
       '#title' => $this->t('IIIF Manifest URL'),
-      '#description' => $this->t('Absolute URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "http://localhost/node/[node:nid]/manifest"'),
+    ];
+    $form['iiif_manifest_url_fieldset']['iiif_manifest_url'] = [
+      '#type' => 'textfield',
+      '#description' => $this->t('Absolute URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "http://localhost/node/[node:nid]/manifest")'),
       '#default_value' => $this->configuration['iiif_manifest_url'],
       '#maxlength' => 256,
       '#size' => 64,
-      '#weight' => '0',
       '#required' => TRUE,
     ];
+    $form['iiif_manifest_url_fieldset']['token_help'] = array(
+      '#theme' => 'token_tree_link',
+      '#token_types' => array('node'),
+    );
+
 
     return $form;
   }

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -29,7 +29,7 @@ class OpenseadragonBlock extends BlockBase {
     $form['iiif_manifest_url'] = [
       '#type' => 'textfield',
       '#title' => $this->t('IIIF Manifest URL'),
-      '#description' => $this->t('URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "http://localhost/node/[node:id]/manifest"'),
+      '#description' => $this->t('Absolute URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "http://localhost/node/[node:nid]/manifest"'),
       '#default_value' => $this->configuration['iiif_manifest_url'],
       '#maxlength' => 256,
       '#size' => 64,

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -50,7 +50,7 @@ class OpenseadragonBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
-    $this->configuration['iiif_manifest_url'] = $form_state->getValue('iiif_manifest_url');
+    $this->configuration['iiif_manifest_url'] = $form_state->getValues()['iiif_manifest_url_fieldset']['iiif_manifest_url'];
   }
 
   /**

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -37,6 +37,8 @@ class OpenseadragonBlock extends BlockBase {
       '#maxlength' => 256,
       '#size' => 64,
       '#required' => TRUE,
+      '#element_validate' => ['token_element_validate'],
+      '#token_types' => ['node'],
     ];
     $form['iiif_manifest_url_fieldset']['token_help'] = [
       '#theme' => 'token_tree_link',
@@ -51,7 +53,7 @@ class OpenseadragonBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
-    $this->configuration['iiif_manifest_url'] = $form_state->getValues()['iiif_manifest_url_fieldset']['iiif_manifest_url'];
+    $this->configuration['iiif_manifest_url'] = $form_state->getValue(['iiif_manifest_url_fieldset', 'iiif_manifest_url']);
   }
 
   /**

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -19,8 +19,7 @@ class OpenseadragonBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return [
-          ] + parent::defaultConfiguration();
+    return [] + parent::defaultConfiguration();
   }
 
   /**
@@ -30,7 +29,7 @@ class OpenseadragonBlock extends BlockBase {
     $form['iiif_manifest_url'] = [
       '#type' => 'textfield',
       '#title' => $this->t('IIIF Manifest URL'),
-      '#description' => $this->t('URL of the IIIF manifest to render.  You may enter an absolute URL or use tokens to provide a pattern (e.g. "node/[node:id]/manifest"'),
+      '#description' => $this->t('URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "http://localhost/node/[node:id]/manifest"'),
       '#default_value' => $this->configuration['iiif_manifest_url'],
       '#maxlength' => 256,
       '#size' => 64,
@@ -55,7 +54,7 @@ class OpenseadragonBlock extends BlockBase {
     $build = [];
     $build['openseadragon_block'] = [
       '#theme' => 'openseadragon_iiif_manifest_block',
-      '#iiif_manifest_url' => $this->configuration['iiif_manifest_url']
+      '#iiif_manifest_url' => $this->configuration['iiif_manifest_url'],
     ];
 
     return $build;

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -38,11 +38,10 @@ class OpenseadragonBlock extends BlockBase {
       '#size' => 64,
       '#required' => TRUE,
     ];
-    $form['iiif_manifest_url_fieldset']['token_help'] = array(
+    $form['iiif_manifest_url_fieldset']['token_help'] = [
       '#theme' => 'token_tree_link',
-      '#token_types' => array('node'),
-    );
-
+      '#token_types' => ['node'],
+    ];
 
     return $form;
   }

--- a/src/Plugin/Block/OpenseadragonBlock.php
+++ b/src/Plugin/Block/OpenseadragonBlock.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\openseadragon\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a 'OpenseadragonBlock' block from a IIIF manifest.
+ *
+ * @Block(
+ *  id = "openseadragon_block",
+ *  admin_label = @Translation("Openseadragon block"),
+ * )
+ */
+class OpenseadragonBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+          ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form['iiif_manifest_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('IIIF Manifest URL'),
+      '#description' => $this->t('URL of the IIIF manifest to render.  You may enter an absolute URL or use tokens to provide a pattern (e.g. "node/[node:id]/manifest"'),
+      '#default_value' => $this->configuration['iiif_manifest_url'],
+      '#maxlength' => 256,
+      '#size' => 64,
+      '#weight' => '0',
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $this->configuration['iiif_manifest_url'] = $form_state->getValue('iiif_manifest_url');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+    $build['openseadragon_block'] = [
+      '#theme' => 'openseadragon_iiif_manifest_block',
+      '#iiif_manifest_url' => $this->configuration['iiif_manifest_url']
+    ];
+
+    return $build;
+  }
+
+}

--- a/templates/openseadragon-iiif-manifest-block.html.twig
+++ b/templates/openseadragon-iiif-manifest-block.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Template to render an Openseadragon viewer using a IIIF manifest.
+ *
+ * Available variables:
+ * - attributes: Container attributes.
+ *
+ * @see template_preprocess_openseadragon_iiif_manifest_block()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('libraries/openseadragon') }}
+{{ attach_library('openseadragon/init') }}
+<div {{ attributes }}></div>

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -1,0 +1,71 @@
+{
+  "@type": "sc:Manifest",
+  "@id": "http://localhost:8000/node/3/book-manifest",
+  "label": "IIIF Manifest",
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "sequences": [
+    {
+      "@context": "http://iiif.io/api/presentation/2/context.json",
+      "@id": "http://localhost:8000/node/3/sequence/normal",
+      "@type": "sc:Sequence",
+      "canvases": [
+        {
+          "@id": "http://localhost:8000/node/3/canvas/1",
+          "@type": "sc:Canvas",
+          "label": "CCITT_1.TIF",
+          "height": 2376,
+          "width": 1728,
+          "images": {
+            "0": {
+              "@id": "http://localhost:8000/node/3/annotation/1",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://127.0.0.1:8080/cantaloupe/iiif/2/derp.TIF/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/tiff",
+                "height": 2376,
+                "width": 1728,
+                "service": {
+                  "@id": "http://127.0.0.1:8080/cantaloupe/iiif/2/derp.TIF",
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "profile": "http://iiif.io/api/image/2/profiles/level2.json"
+                }
+              },
+              "on": "http://localhost:8000/node/3/canvas/1"
+            },
+            "on": "http://localhost:8000/node/3/canvas/1"
+          }
+        },
+        {
+          "@id": "http://localhost:8000/node/3/canvas/12",
+          "@type": "sc:Canvas",
+          "label": "citywalk.jpg",
+          "height": 1074,
+          "width": 1494,
+          "images": {
+            "0": {
+              "@id": "http://localhost:8000/node/3/annotation/12",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "http://127.0.0.1:8080/cantaloupe/iiif/2/derp.jpeg/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1074,
+                "width": 1494,
+                "service": {
+                  "@id": "http://127.0.0.1:8080/cantaloupe/iiif/2/derp.jpeg",
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "profile": "http://iiif.io/api/image/2/profiles/level2.json"
+                }
+              },
+              "on": "http://localhost:8000/node/3/canvas/12"
+            },
+            "on": "http://localhost:8000/node/3/canvas/12"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/Kernel/IIIFManifestParserTest.php
+++ b/tests/src/Kernel/IIIFManifestParserTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Drupal\Tests\openseadragon\Kernel;
+
+use Drupal\Core\Utility\Token;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\openseadragon\IIIFManifestParser;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class IIIFManifestParserTest.
+ *
+ * @package Drupal\Tests\openseadragon\Kernel
+ * @group openseadragon
+ * @coversDefaultClass Drupal\openseadragon\IIIFManifestParser
+ */
+class IIIFManifestParserTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'node',
+    'user',
+    'openseadragon',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Bootstrap minimal Drupal environment to run the tests.
+    $this->installSchema('system', 'sequences');
+    $this->installSchema('node', 'node_access');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+
+    // Create a test content type.
+    $this->testType = $this->container->get('entity_type.manager')->getStorage('node_type')->create([
+      'type' => 'test_type',
+      'name' => 'Test Type',
+    ]);
+  }
+
+  /**
+   * @covers ::getTileSources
+   */
+  public function testGetTileSourcesReturnsFalseOnRequestFail() {
+
+    $token = $this->prophesize(Token::class)->reveal();
+
+    $route_match = $this->prophesize(RouteMatchInterface::class)->reveal();
+
+    $mock = new MockHandler([
+      new Response(404, [], "Not Found"),
+    ]);
+    $handler = HandlerStack::create($mock);
+    $http_client = new Client(['handler' => $handler]);
+
+    $logger = $this->prophesize(LoggerInterface::class)->reveal();
+
+    $parser = new IIIFManifestParser(
+      $token,
+      $route_match,
+      $http_client,
+      $logger
+    );
+
+    $this->assertFalse(
+      $parser->getTileSources('http://example.org/does/not/exist'),
+      "Parser should return FALSE if manifest URL does not return 200"
+    );
+  }
+
+  /**
+   * @covers ::getTileSources
+   */
+  public function testGetTileSourcesReturnsFalseOnEmptyManifest() {
+
+    $token = $this->prophesize(Token::class)->reveal();
+
+    $route_match = $this->prophesize(RouteMatchInterface::class)->reveal();
+
+    $mock = new MockHandler([
+      new Response(204, [], ""),
+    ]);
+    $handler = HandlerStack::create($mock);
+    $http_client = new Client(['handler' => $handler]);
+
+    $logger = $this->prophesize(LoggerInterface::class)->reveal();
+
+    $parser = new IIIFManifestParser(
+      $token,
+      $route_match,
+      $http_client,
+      $logger
+    );
+
+    $this->assertFalse(
+      $parser->getTileSources('http://example.org/exists/but/is/empty'),
+      "Parser should return FALSE if manifest URL does not a response body"
+    );
+  }
+
+  /**
+   * @covers ::getTileSources
+   */
+  public function testGetTileSourcesReturnsFalseOnMalformedManifest() {
+
+    $token = $this->prophesize(Token::class)->reveal();
+
+    $route_match = $this->prophesize(RouteMatchInterface::class)->reveal();
+
+    $mock = new MockHandler([
+      new Response(200, [], "<xml>Totally not json</xml>"),
+    ]);
+    $handler = HandlerStack::create($mock);
+    $http_client = new Client(['handler' => $handler]);
+
+    $logger = $this->prophesize(LoggerInterface::class)->reveal();
+
+    $parser = new IIIFManifestParser(
+      $token,
+      $route_match,
+      $http_client,
+      $logger
+    );
+
+    $this->assertFalse(
+      $parser->getTileSources('http://example.org/exists/but/is/malformed'),
+      "Parser should return FALSE if manifest URL does not return JSON"
+    );
+  }
+
+  /**
+   * @covers ::getTileSources
+   */
+  public function testGetTileSources() {
+
+    $token = $this->prophesize(Token::class)->reveal();
+
+    $route_match = $this->prophesize(RouteMatchInterface::class)->reveal();
+
+    $manifest = file_get_contents(__DIR__ . '/../../resources/manifest.json');
+
+    $mock = new MockHandler([
+      new Response(200, [], $manifest),
+    ]);
+
+    $handler = HandlerStack::create($mock);
+    $http_client = new Client(['handler' => $handler]);
+
+    $logger = $this->prophesize(LoggerInterface::class)->reveal();
+
+    $parser = new IIIFManifestParser(
+      $token,
+      $route_match,
+      $http_client,
+      $logger
+    );
+
+    $tile_sources = $parser->getTileSources('http://example.org/manifest');
+    $expected = [
+      'http://127.0.0.1:8080/cantaloupe/iiif/2/derp.TIF',
+      'http://127.0.0.1:8080/cantaloupe/iiif/2/derp.jpeg',
+    ];
+    $this->assertTrue(
+      empty(array_diff($tile_sources, $expected)),
+      "Expected " . json_encode($tile_sources) . ", recieved " . json_encode($tile_sources)
+    );
+  }
+
+  /**
+   * @covers ::getTileSources
+   */
+  public function testGetTileSourcesWithTokens() {
+
+    $token = $this->container->get('token');
+
+    $node = Node::create(['type' => 'test_type', 'title' => 'Test']);
+    $node->save();
+
+    $route_match = $this->prophesize(RouteMatchInterface::class);
+    $route_match->getParameter('node')->willReturn($node);
+    $route_match = $route_match->reveal();
+
+    $manifest = file_get_contents(__DIR__ . '/../../resources/manifest.json');
+    $http_client = $this->prophesize(Client::class);
+    $http_client->get("http://example.org/node/{$node->id()}/manifest")->willReturn(new Response(200, [], $manifest));
+    $http_client = $http_client->reveal();
+
+    $logger = $this->prophesize(LoggerInterface::class)->reveal();
+
+    $parser = new IIIFManifestParser(
+      $token,
+      $route_match,
+      $http_client,
+      $logger
+    );
+
+    $tile_sources = $parser->getTileSources('http://example.org/node/[node:nid]/manifest');
+    $expected = [
+      'http://127.0.0.1:8080/cantaloupe/iiif/2/derp.TIF',
+      'http://127.0.0.1:8080/cantaloupe/iiif/2/derp.jpeg',
+    ];
+    $this->assertTrue(
+      empty(array_diff($tile_sources, $expected)),
+      "Expected " . json_encode($tile_sources) . ", recieved " . json_encode($tile_sources)
+    );
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/932

# What does this Pull Request do?

Adds a block you can place using Context that uses IIIF manifests to render a multi-page openseadragon viewer.

# What's new?
A new type of block, which takes a IIIF manifest url (or a url pattern using tokens) as configuration.

Tests.

# How should this be tested?

- Set your openseadragon settings to use 'Sequence Mode' if you want multiple pages.
- Make a view that renders manifests using our IIIF Manifest views style plugin (or just use [this](https://gist.github.com/dannylamb/c90686957d3d5599f49f2cab02f045d4))
- Make a block using the block placement screen and enter a manifest URL in the config
- If you really wanna go for it, place the block using context when the node has the 'Paged Content' tag, and use `http://localhost:8000/node/[node:nid]/book-manifest` as the IIIF Manifest url.
  - Remember, you can adjust weights between the core and context block placement UIs to put that block wherever you want, like slighly above the main content but below the tabs, for example.
- Behold your multi-page openseadragon viewer rendered using a IIIF manifest!

# Additional Notes:
We'll need additional default config in order to pin down the manifest view and the context, but you get the picture.

# Interested parties
@Islandora-CLAW/committers @dbernstein @elizoller @rangel35 
